### PR TITLE
Fix compilation on Rust nightly 2015-01-05.

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -334,7 +334,6 @@ pub fn user_lexer_impl(cx: &mut ExtCtxt, sp: Span, lex:&Lexer) -> Vec<P<ast::Ite
 
                 // execute action corresponding to found state
                 let action_result = $actions_match(self) ;
-                debug!("action returned {}", action_result);
 
                 match action_result {
                     Some(token) => return Some(token),

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -1,3 +1,4 @@
+use std::iter;
 use nfa;
 use std::result;
 use util;
@@ -11,7 +12,7 @@ struct State {
     // this is not strictly speaking
     // a DFA since there may be no
     // transitions for a given input
-    pub trans: [uint, .. 256],
+    pub trans: [uint; 256],
 
     // for DFA determinization
     // remember the set of NFA states
@@ -99,7 +100,7 @@ impl Automaton {
     #[inline(always)]
     fn create_state(&mut self, act: uint, states: Option<Box<util::BinSet>>) -> uint {
         self.states.push(State {
-            trans: [0, .. 256],
+            trans: [0; 256],
             states: match states {
                 Some(s) => s,
                 None => box util::BinSet::new(0u)
@@ -129,7 +130,7 @@ impl Automaton {
         // of subgroups of the form (gr, st) where gr is the number of the
         // subgroup (it may be the same as the original group), and st the
         // number of a representing state
-        let mut subgroups: Vec<Vec<(uint, uint)>> = Vec::from_elem(acts_count, vec!());
+        let mut subgroups: Vec<Vec<(uint, uint)>> = iter::repeat(vec!()).take(acts_count).collect();
         loop {
             // subgroups become groups, reinitialize subgroups
             for i in subgroups.iter_mut() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![feature(plugin_registrar)]
-#![feature(phase)]
 #![feature(quote)]
-#![feature(macro_rules)]
+#![feature(box_syntax)]
+#![feature(int_uint)]
 
 #![crate_type="dylib"]
 #![crate_name="rustlex"]
@@ -10,7 +10,7 @@ extern crate collections;
 extern crate syntax;
 extern crate rustc;
 
-#[phase(plugin, link)] extern crate log;
+#[macro_use] extern crate log;
 
 use syntax::ast::{Ident, TokenTree};
 use syntax::codemap::Span;

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -3,7 +3,7 @@ use util::BinSetu8;
 
 pub use self::Regex::{Or, Cat, Maybe, Closure, Class, NotClass, Var, Char, Any};
 
-#[deriving(Clone)]
+#[derive(Clone)]
 pub enum Regex {
     // binary operators
     Or(Box<Regex>, Box<Regex>),

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -1,3 +1,5 @@
+use std::ops::IndexMut;
+
 static RUSTLEX_BUFSIZE: uint = 4096;
 
 pub struct RustLexBuffer {
@@ -32,7 +34,7 @@ impl RustLexBuffer {
     }
 }
 
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct RustLexPos {
     pub buf: uint,
     pub off: uint

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -57,7 +57,7 @@ pub struct RustLexLexer<R : Reader> {
 
 impl<R: ::std::io::Reader> RustLexLexer<R> {
     fn fill_buf(&mut self) {
-        let &RustLexBuffer {
+        let &mut RustLexBuffer {
             ref mut d,
             ref mut valid
         } = self.inp.index_mut(&self.pos.buf);

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,4 @@
+use std::iter;
 use std::slice::Iter;
 
 // A vector type optimized for cases where the size is almost always 0 or 1
@@ -37,7 +38,7 @@ pub struct BinSet {
 // FIXME: make generic
 // currently we can't write something like impl<T: Bound> where Bound
 // would allow T to be shifted or bitor/and'd by any numeric type
-#[deriving(Clone)]
+#[derive(Clone)]
 pub struct BinSetu8 {
     pub data: Vec<u64>,
     pub states: Vec<u8>
@@ -68,7 +69,7 @@ impl BinSet {
         // (state_count / 64) + 1
         let chunks = (state_count >> 6) + 1;
         BinSet {
-            data: Vec::from_elem(chunks, 0u64),
+            data: iter::repeat(0).take(chunks).collect(),
             states: Vec::with_capacity(state_count),
             action: 0
         }
@@ -116,7 +117,7 @@ impl BinSetu8 {
         // (state_count / 64) + 1
         let chunks = (state_count >> 6) + 1;
         BinSetu8 {
-            data: Vec::from_elem(chunks, 0u64),
+            data: iter::repeat(0).take(chunks).collect(),
             states: Vec::with_capacity(state_count)
         }
     }

--- a/tests/complex.rs
+++ b/tests/complex.rs
@@ -8,7 +8,7 @@ use std::io::BufReader;
 // each call and must be declared in the same module
 // as where the rustlex! macro is invoked
 use self::Token::{TokInt, TokFloat, TokId, TokString};
-#[deriving(PartialEq,Show)]
+#[derive(PartialEq,Show)]
 enum Token {
     TokInt(u32),
     TokFloat(f32),
@@ -39,16 +39,16 @@ rustlex! ComplexLexer {
     // each rule is of the form
     //    regex => action
     // action can be a block or a single statement
-    INT => |lexer:&mut ComplexLexer<R>| Some(TokInt(from_str::<u32>(lexer.yystr().as_slice()).unwrap()))
-    HEX => |lexer:&mut ComplexLexer<R>| {
+    INT => |&: lexer:&mut ComplexLexer<R>| Some(TokInt(lexer.yystr().as_slice().parse().unwrap()))
+    HEX => |&: lexer:&mut ComplexLexer<R>| {
         let s = lexer.yystr();
         let s = s.as_slice();
         let i:u32 = ::std::num::from_str_radix(s.slice(2, s.len()-1), 16).unwrap();
         Some(TokInt(i))
     }
-    FLTCONST => |lexer:&mut ComplexLexer<R>| Some(TokFloat(from_str::<f32>(lexer.yystr().as_slice()).unwrap()))
-    ID => |lexer:&mut ComplexLexer<R>| Some(TokId(lexer.yystr()))
-    STR => |lexer:&mut ComplexLexer<R>| Some(TokString(lexer.yystr()))
+    FLTCONST => |&: lexer:&mut ComplexLexer<R>| Some(TokFloat(lexer.yystr().as_slice().parse().unwrap()))
+    ID => |&: lexer:&mut ComplexLexer<R>| Some(TokId(lexer.yystr()))
+    STR => |&: lexer:&mut ComplexLexer<R>| Some(TokString(lexer.yystr()))
 }
 
 #[test]

--- a/tests/complex.rs
+++ b/tests/complex.rs
@@ -1,6 +1,8 @@
-#![feature(phase)]
-#[phase(plugin, link)] extern crate rustlex;
-#[phase(plugin, link)] extern crate log;
+#![feature(int_uint)]
+#![feature(plugin)]
+
+#[plugin] extern crate rustlex;
+#[macro_use] extern crate log;
 
 use std::io::BufReader;
 

--- a/tests/condition.rs
+++ b/tests/condition.rs
@@ -6,7 +6,7 @@ use std::io::BufReader;
 
 use self::Token::{TokOuterStuff, TokInnerStuff};
 
-#[deriving(PartialEq,Show)]
+#[derive(PartialEq,Show)]
 enum Token {
     TokOuterStuff(String),
     TokInnerStuff(String)
@@ -17,17 +17,17 @@ rustlex! ConditionLexer {
     let CLOSE = '}';
     let STUFF = [^'{''}']*;
     INITIAL {
-        STUFF => |lexer: &mut ConditionLexer<R>|
+        STUFF => |&: lexer: &mut ConditionLexer<R>|
             Some(TokOuterStuff(lexer.yystr().trim().to_string()))
-        OPEN => |lexer: &mut ConditionLexer<R>| {
+        OPEN => |&: lexer: &mut ConditionLexer<R>| {
             lexer.INNER();
             None
         }
     }
     INNER {
-        STUFF => |lexer: &mut ConditionLexer<R>|
+        STUFF => |&: lexer: &mut ConditionLexer<R>|
             Some(TokInnerStuff(lexer.yystr().trim().to_string()))
-        CLOSE => |lexer: &mut ConditionLexer<R>| {
+        CLOSE => |&: lexer: &mut ConditionLexer<R>| {
             lexer.INITIAL();
             None
         }

--- a/tests/condition.rs
+++ b/tests/condition.rs
@@ -1,6 +1,8 @@
-#![feature(phase)]
-#[phase(plugin, link)] extern crate rustlex;
-#[phase(plugin, link)] extern crate log;
+#![feature(int_uint)]
+#![feature(plugin)]
+
+#[plugin] extern crate rustlex;
+#[macro_use] extern crate log;
 
 use std::io::BufReader;
 

--- a/tests/properties.rs
+++ b/tests/properties.rs
@@ -6,7 +6,7 @@ use std::io::BufReader;
 
 use self::Token::{Open,Close};
 
-#[deriving(PartialEq,Show)]
+#[derive(PartialEq,Show)]
 enum Token {
     Open,
     Close
@@ -16,8 +16,8 @@ rustlex! PropertiesLexer {
     property depth:int = 0;
     let OPEN = '(';
     let CLOSE = ')';
-    OPEN => |lexer:&mut PropertiesLexer<R>| { lexer.depth += 1; Some(Open) }
-    CLOSE => |lexer:&mut PropertiesLexer<R>| {
+    OPEN => |&: lexer:&mut PropertiesLexer<R>| { lexer.depth += 1; Some(Open) }
+    CLOSE => |&: lexer:&mut PropertiesLexer<R>| {
         lexer.depth -= 1;
         if lexer.depth<0 { panic!("invalid parens nesting") };
         Some(Close) }

--- a/tests/properties.rs
+++ b/tests/properties.rs
@@ -1,6 +1,8 @@
-#![feature(phase)]
-#[phase(plugin, link)] extern crate rustlex;
-#[phase(plugin, link)] extern crate log;
+#![feature(int_uint)]
+#![feature(plugin)]
+
+#[plugin] extern crate rustlex;
+#[macro_use] extern crate log;
 
 use std::io::BufReader;
 

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -7,14 +7,14 @@ use std::io::BufReader;
 use self::Token::TokA;
 use self::TokenB::TokB;
 
-#[deriving(PartialEq,Show)]
+#[derive(PartialEq,Show)]
 enum Token {
     TokA(String),
 }
 
 rustlex! SimpleLexer {
     let A = 'a';
-    A => |lexer:&mut SimpleLexer<R>| Some(TokA ( lexer.yystr() ))
+    A => |&: lexer:&mut SimpleLexer<R>| Some(TokA ( lexer.yystr() ))
 }
 
 #[test]
@@ -30,7 +30,7 @@ fn test_simple() {
     assert!(iter.next() == None);
 }
 
-#[deriving(PartialEq,Show)]
+#[derive(PartialEq,Show)]
 enum TokenB {
     TokB(String)
 }
@@ -38,7 +38,7 @@ enum TokenB {
 rustlex! OtherLexer {
     token TokenB;
     let B = 'b';
-    B => |lexer:&mut OtherLexer<R>| Some(TokB ( lexer.yystr() ))
+    B => |&: lexer:&mut OtherLexer<R>| Some(TokB ( lexer.yystr() ))
 }
 
 #[test]

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -1,6 +1,8 @@
-#![feature(phase)]
-#[phase(plugin, link)] extern crate rustlex;
-#[phase(plugin, link)] extern crate log;
+#![feature(int_uint)]
+#![feature(plugin)]
+
+#[plugin] extern crate rustlex;
+#[macro_use] extern crate log;
 
 use std::io::BufReader;
 


### PR DESCRIPTION
As the title says, this patch fixes the build with the latest `rustc`. Most changes come from the churn in the collection API and the removal of the unboxed closures. The only thing that's a bit ugly is the fact that the compiler is unable to unify closure types in match arms. So `as Box<Fn(_) -> _>` is required after each arm in `codegen.rs`.