### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ rustlex! SimpleLexer {
     let A = 'a';
 
     // then rules
-    A => |&: lexer:&mut SimpleLexer<R>| Some(TokA ( lexer.yystr() ))
+    A => |lexer:&mut SimpleLexer<R>| Some(TokA ( lexer.yystr() ))
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ and add the following lines at the top of your crate:
 ```rust
 #![feature(plugin)]
 #![plugin(rustlex)]
-#[allow(library_as_plugin)] extern crate rustlex;
+#[allow(plugin_as_library)] extern crate rustlex;
 #[macro_use] extern crate log;
 ```
 


### PR DESCRIPTION
The example used obsolete syntax giving:

```
error: obsolete syntax: `:`, `&mut:`, or `&:`
```
and gave a warning:

```
warning: unknown `allow` attribute: `library_as_plugin`, #[warn(unknown_lints)] on by default
```