### PR TITLE
Add macro-like inheritance/includes inside conditions

### DIFF
--- a/codegen/src/lexer.rs
+++ b/codegen/src/lexer.rs
@@ -15,6 +15,7 @@ use syntax::ptr::P;
 // to a Rust code snippet
 // unfortunately we have to use borrowed pointers since
 // this is what libsyntax gives usn
+#[derive(Clone)]
 pub struct Rule {
     pub pattern: Box<Regex>,
     pub action: P<Expr>


### PR DESCRIPTION
Use these rules by specifying a condition name with a colon inside a different condition. Example:
```
I_TEST {
	PATTERN => |lexer:&mut MyLexer<R>| Some(TokTest)
}

CONDITION {
	FIRST_PATTERN => |lexer:&mut MyLexer<R>| Some(TokFirst)
	:I_TEST
	ANOTHER_PATTERN => |lexer:&mut MyLexer<R>| Some(TokAnother)
}
```

This is useful if you have a lot of conditions and you want to avoid code duplication.