### PR TITLE
update to latest rust change

### DIFF
--- a/codegen/src/parser.rs
+++ b/codegen/src/parser.rs
@@ -148,7 +148,7 @@ fn get_char_class<T: Tokenizer>(parser: &mut T)
             }
 
             token::Literal(token::Lit::Char(i), _) => {
-                let mut ch = parse::char_lit(i.as_str()).0 as u8;
+                let mut ch = parse::char_lit(&*i.as_str()).0 as u8;
 
                 match *parser.token() {
                     token::BinOp(token::Minus) => {
@@ -156,7 +156,7 @@ fn get_char_class<T: Tokenizer>(parser: &mut T)
                         try!(parser.bump());
                         let ch2 = match try!(parser.bump_and_get()) {
                             token::Literal(token::Lit::Char(ch), _) =>
-                                parse::char_lit(ch.as_str()).0 as u8,
+                                parse::char_lit(&*ch.as_str()).0 as u8,
                             _ => return Err(parser.unexpected())
                         };
                         if ch >= ch2 {
@@ -175,7 +175,7 @@ fn get_char_class<T: Tokenizer>(parser: &mut T)
             }
 
             token::Literal(token::Lit::Str_(id),_) => {
-                let s = token::get_name(id);
+                let s = id.as_str();
                 if s.len() == 0 {
                     let last_span = parser.last_span();
                     return Err(parser.span_fatal(last_span,
@@ -217,9 +217,9 @@ fn get_const<T: Tokenizer>(parser: &mut T, env: &Env)
             }
         }
         token::Literal(token::Lit::Char(ch), _) =>
-            Ok(Box::new(regex::Char(parse::char_lit(ch.as_str()).0 as u8))),
+            Ok(Box::new(regex::Char(parse::char_lit(&*ch.as_str()).0 as u8))),
         token::Literal(token::Lit::Str_(id), _) =>
-            match regex::string(&*token::get_name(id)) {
+            match regex::string(&*id.as_str()) {
                 Some(reg) => Ok(reg),
                 None => {
                     let last_span = parser.last_span();
@@ -233,7 +233,7 @@ fn get_const<T: Tokenizer>(parser: &mut T, env: &Env)
                 let last_span = parser.last_span();
                 Err(parser.span_fatal(last_span,
                 &format!("unknown identifier: {}",
-                    token::get_name(id.name))))
+                    id.name.as_str())))
             }
         },
         _ => Err(parser.unexpected_last(&tok))


### PR DESCRIPTION
A [recent syntax change](https://github.com/rust-lang/rust/commit/00a5e66f818ad9d79cc4425f5564c7b07e3213a6) removed `get_name()` and `get_ident()` functions in favor of inherent `Name::as_str()` method.

As I use this package with nightly, I needed the update, and here I share it.