### PR TITLE
Update (mostly codegen) to compile with nightly Rust.

### DIFF
--- a/codegen/src/lexer.rs
+++ b/codegen/src/lexer.rs
@@ -106,9 +106,10 @@ impl Lexer {
         for &s in dfas.initials.iter() {
             let regex::Action(act) = dfas.states[s].data;
             if act != 0 {
-                cx.span_err(acts[act].span, "this rule accepts the empty word");
-                cx.fileline_help(acts[act].span, "this might cause the automaton \
-                        to loop on some inputs");
+                cx.struct_span_err(acts[act].span, "this rule accepts the empty word")
+                  .fileline_help(acts[act].span, "this might cause the automaton \
+                      to loop on some inputs")
+                  .emit();
             }
         }
 
@@ -117,17 +118,19 @@ impl Lexer {
             analysis::check_automaton(&dfas, acts.len());
 
         for regex::Action(act) in unreachable.into_iter() {
-            cx.span_err(acts[act].span, "unreachable pattern");
-            cx.fileline_help(acts[act].span, "make sure it is not included \
-                    in another pattern ; latter patterns have precedence");
+            cx.struct_span_err(acts[act].span, "unreachable pattern")
+              .fileline_help(acts[act].span, "make sure it is not included \
+                  in another pattern ; latter patterns have precedence")
+              .emit();
         }
 
         for cond in incomplete.into_iter() {
-            cx.span_err(def.conditions[cond].span, "this automaton is incomplete");
-            cx.fileline_help(def.conditions[cond].span, "maybe add a catch-all rule?");
+            cx.struct_span_err(def.conditions[cond].span, "this automaton is incomplete")
+              .fileline_help(def.conditions[cond].span, "maybe add a catch-all rule?")
+              .emit();
         }
 
-        cx.parse_sess.span_diagnostic.handler.abort_if_errors();
+        cx.parse_sess.span_diagnostic.abort_if_errors();
 
         info!("minimizing...");
         Lexer {

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -5,7 +5,7 @@
 #[cfg(feature = "with-syntex")] extern crate syntex_syntax as syntax;
 
 #[cfg(not(feature = "with-syntex"))] extern crate syntax;
-#[cfg(not(feature = "with-syntex"))] extern crate rustc;
+#[cfg(not(feature = "with-syntex"))] extern crate rustc_plugin;
 
 #[macro_use] extern crate log;
 extern crate bit_set;
@@ -43,7 +43,7 @@ pub fn plugin_registrar(reg: &mut syntex::Registry) {
 }
 
 #[cfg(not(feature = "with-syntex"))]
-pub fn plugin_registrar(reg: &mut rustc::plugin::Registry) {
+pub fn plugin_registrar(reg: &mut rustc_plugin::Registry) {
     reg.register_syntax_extension(
         syntax::parse::token::intern("rustlex"),
         syntax::ext::base::IdentTT(Box::new(rustlex), None, false)

--- a/codegen/src/parser.rs
+++ b/codegen/src/parser.rs
@@ -16,25 +16,26 @@ use syntax::codemap::Span;
 use syntax::parse;
 use syntax::parse::token;
 use syntax::parse::token::keywords;
-use syntax::diagnostic::FatalError;
 use syntax::parse::parser::Parser;
+use syntax::errors::DiagnosticBuilder;
 use syntax::ptr::P;
 
-trait Tokenizer {
+
+trait Tokenizer<'a> {
     // returns the current token, without consuming it
-    fn token<'a>(&'a self) -> &'a token::Token;
+    fn token(&self) -> &token::Token;
 
     // consumes the current token
-    fn bump(&mut self) -> Result<(),FatalError>;
+    fn bump(&mut self) -> ();
 
     // consumes the current token and return it
     // equivalent to token() followed by bump()
-    fn bump_and_get(&mut self) -> Result<token::Token,FatalError>;
+    fn bump_and_get(&mut self) -> token::Token;
 
     // consumes the current token and return true if
     // it corresponds to tok, or false otherwise
-    fn eat(&mut self, tok: &token::Token) -> Result<bool,FatalError>;
-    fn eat_keyword(&mut self, kwd: token::keywords::Keyword) -> Result<bool,FatalError>;
+    fn eat(&mut self, tok: &token::Token) -> bool;
+    fn eat_keyword(&mut self, kwd: token::keywords::Keyword) -> bool;
 
     // returns true if the next token is the given
     // token or keyword, without consuming it
@@ -43,30 +44,30 @@ trait Tokenizer {
 
     // expects the following token to be the
     // same as the given token, then consumes it
-    fn expect(&mut self, tok: &token::Token) -> Result<(),FatalError>;
+    fn expect(&mut self, tok: &token::Token) -> Result<(),DiagnosticBuilder<'a>>;
 
     // expect the next token to be an ident and consumes it
-    fn parse_ident(&mut self) -> Result<Ident, FatalError>;
+    fn parse_ident(&mut self) -> Result<Ident, DiagnosticBuilder<'a>>;
 
     // returns the span of the previous token
     fn last_span(&self) -> Span;
 
     // various functions to abort parsing
-    fn span_fatal(&mut self, sp: Span, m: &str) -> FatalError;
-    fn unexpected(&mut self) -> FatalError;
-    fn unexpected_last(&mut self, tok: &token::Token) -> FatalError;
+    fn span_fatal(&mut self, sp: Span, m: &str) -> DiagnosticBuilder<'a>;
+    fn unexpected(&mut self) -> DiagnosticBuilder<'a>;
+    fn unexpected_last(&mut self, tok: &token::Token) -> DiagnosticBuilder<'a>;
 }
 
-impl<'a> Tokenizer for Parser<'a> {
+impl<'a> Tokenizer<'a> for Parser<'a> {
     fn token(&self) -> &token::Token { &self.token }
-    fn bump(&mut self) -> Result<(),FatalError> { self.bump() }
-    fn bump_and_get(&mut self) -> Result<token::Token,FatalError> {
+    fn bump(&mut self) { self.bump() }
+    fn bump_and_get(&mut self) -> token::Token {
         self.bump_and_get()
     }
-    fn eat(&mut self, tok: &token::Token) -> Result<bool,FatalError> {
+    fn eat(&mut self, tok: &token::Token) -> bool {
         self.eat(tok)
     }
-    fn eat_keyword(&mut self, kwd: token::keywords::Keyword) -> Result<bool,FatalError> {
+    fn eat_keyword(&mut self, kwd: token::keywords::Keyword) -> bool {
         self.eat_keyword(kwd)
     }
     fn check(&mut self, tok: &token::Token) -> bool {
@@ -75,28 +76,28 @@ impl<'a> Tokenizer for Parser<'a> {
     fn check_keyword(&mut self, kwd: token::keywords::Keyword) -> bool {
         self.check_keyword(kwd)
     }
-    fn expect(&mut self, tok: &token::Token) -> Result<(),FatalError> {
+    fn expect(&mut self, tok: &token::Token) -> Result<(),DiagnosticBuilder<'a>> {
         self.expect(tok)
     }
-    fn parse_ident(&mut self) -> Result<Ident, FatalError> { self.parse_ident() }
+    fn parse_ident(&mut self) -> Result<Ident, DiagnosticBuilder<'a>> { self.parse_ident() }
     fn last_span(&self) -> Span { self.last_span }
-    fn span_fatal(&mut self, sp: Span, m: &str) -> FatalError {
+    fn span_fatal(&mut self, sp: Span, m: &str) -> DiagnosticBuilder<'a> {
         Parser::span_fatal(self, sp, m)
     }
-    fn unexpected(&mut self) -> FatalError { Parser::unexpected(self) }
-    fn unexpected_last(&mut self, tok: &token::Token) -> FatalError {
-        Parser::unexpected_last(self, tok)
+    fn unexpected(&mut self) -> DiagnosticBuilder<'a> { Parser::unexpected::<()>(self).unwrap_err() }
+    fn unexpected_last(&mut self, tok: &token::Token) -> DiagnosticBuilder<'a> {
+        Parser::unexpected_last::<()>(self, tok).unwrap_err()
     }
 }
 
 // the "lexical" environment of regular expression definitions
 type Env = HashMap<Name, usize>;
 
-fn get_tokens(parser: &mut Parser) -> Result<Ident,FatalError> {
+fn get_tokens<'a>(parser: &mut Parser<'a>) -> Result<Ident,DiagnosticBuilder<'a>> {
     let token = token::intern("token");
     match parser.token {
         token::Ident(id, _) if id.name == token => {
-            try!(parser.bump());
+            parser.bump();
             let token = try!(parser.parse_ident());
             try!(parser.expect(&token::Semi));
             Ok(token)
@@ -105,19 +106,19 @@ fn get_tokens(parser: &mut Parser) -> Result<Ident,FatalError> {
     }
 }
 
-fn get_properties<'a>(parser: &mut Parser)
-        -> Result<Vec<(Name, P<Ty>, P<Expr>)>,FatalError> {
+fn get_properties<'a>(parser: &mut Parser<'a>)
+        -> Result<Vec<(Name, P<Ty>, P<Expr>)>,DiagnosticBuilder<'a>> {
     let mut ret = Vec::new();
     let prop = token::intern("property");
     loop {
         match parser.token {
             token::Ident(id, _) if id.name == prop => {
-                try!(parser.bump());
+                parser.bump();
                 let name = try!(parser.parse_ident());
                 try!(parser.expect(&token::Colon));
-                let ty = parser.parse_ty();
+                let ty = try!(parser.parse_ty());
                 try!(parser.expect(&token::Eq));
-                let expr = parser.parse_expr();
+                let expr = try!(parser.parse_expr());
                 try!(parser.expect(&token::Semi));
                 ret.push((name.name, ty, expr));
             }
@@ -135,11 +136,11 @@ fn get_properties<'a>(parser: &mut Parser)
 
 // recursively parses a character class, e.g. ['a'-'z''0'-'9''_']
 // basically creates an or-expression per character in the class
-fn get_char_class<T: Tokenizer>(parser: &mut T)
-        -> Result<regex::CharSet<char>, FatalError> {
+fn get_char_class<'a, T: Tokenizer<'a>>(parser: &mut T)
+        -> Result<regex::CharSet<char>, DiagnosticBuilder<'a>> {
     let mut ret = regex::CharSet::new();
     loop {
-        let tok = try!(parser.bump_and_get());
+        let tok = parser.bump_and_get();
         match tok {
             token::CloseDelim(token::Bracket) => {
                 break
@@ -151,8 +152,8 @@ fn get_char_class<T: Tokenizer>(parser: &mut T)
                 match *parser.token() {
                     token::BinOp(token::Minus) => {
                         // a char seq, e.g. 'a' - 'Z'
-                        try!(parser.bump());
-                        let ch2 = match try!(parser.bump_and_get()) {
+                        parser.bump();
+                        let ch2 = match parser.bump_and_get() {
                             token::Literal(token::Lit::Char(ch), _) =>
                                 parse::char_lit(&*ch.as_str()).0,
                             _ => return Err(parser.unexpected())
@@ -192,9 +193,9 @@ fn get_char_class<T: Tokenizer>(parser: &mut T)
 // - an identifier refering to another expression
 // parenthesized subexpressions are also parsed here since the have
 // the same operator precedence as the constants
-fn get_const<T: Tokenizer>(parser: &mut T, env: &Env)
-        -> Result<Regex,FatalError> {
-    let tok = try!(parser.bump_and_get());
+fn get_const<'a, T: Tokenizer<'a>>(parser: &mut T, env: &Env)
+        -> Result<Regex,DiagnosticBuilder<'a>> {
+    let tok = parser.bump_and_get();
     // here we expect either
     // the start of a character-class, '['
     // the start of a parenthesized expression, '('
@@ -204,7 +205,7 @@ fn get_const<T: Tokenizer>(parser: &mut T, env: &Env)
         token::OpenDelim(token::Paren) => get_regex(parser,
             &token::CloseDelim(token::Paren), env),
         token::OpenDelim(token::Bracket) => {
-            if try!(parser.eat(&token::BinOp(token::Caret))) {
+            if parser.eat(&token::BinOp(token::Caret)) {
                 Ok(Box::new(regex::Literal(
                     regex::NotClass(try!(get_char_class(parser)))
                 )))
@@ -241,14 +242,14 @@ fn get_const<T: Tokenizer>(parser: &mut T, env: &Env)
 
 // a "closure" in a regular expression, i.e. expr*
 // the * operator has lower precedence that concatenation
-fn get_closure<T: Tokenizer>(parser: &mut T, env: &Env)
-        -> Result<Regex,FatalError> {
+fn get_closure<'a, T: Tokenizer<'a>>(parser: &mut T, env: &Env)
+        -> Result<Regex,DiagnosticBuilder<'a>> {
     let reg = try!(get_const(parser, env));
-    if try!(parser.eat(&token::BinOp(token::Star))) {
+    if parser.eat(&token::BinOp(token::Star)) {
         Ok(Box::new(regex::Closure(reg)))
-    } else if try!(parser.eat(&token::BinOp(token::Plus))) {
+    } else if parser.eat(&token::BinOp(token::Plus)) {
         Ok(Box::new(regex::Cat(reg.clone(), Box::new(regex::Closure(reg)))))
-    } else if try!(parser.eat(&token::Question)) {
+    } else if parser.eat(&token::Question) {
         Ok(Box::new(regex::Maybe(reg))) }
     else {
         Ok(reg)
@@ -259,8 +260,8 @@ fn get_closure<T: Tokenizer>(parser: &mut T, env: &Env)
 // continues until it reaches the end of the current subexpr,
 // indicated by the end parameter or an or operator, which has
 // higher precedence. Concatenation is left-assoc
-fn get_concat<T: Tokenizer>(parser: &mut T, end: &token::Token, env: &Env)
-    -> Result<Regex,FatalError> {
+fn get_concat<'a, T: Tokenizer<'a>>(parser: &mut T, end: &token::Token, env: &Env)
+    -> Result<Regex,DiagnosticBuilder<'a>> {
     let opl = try!(get_closure(parser, env));
     if parser.check(end) ||
         parser.check_keyword(token::keywords::As) ||
@@ -273,10 +274,10 @@ fn get_concat<T: Tokenizer>(parser: &mut T, end: &token::Token, env: &Env)
 }
 
 // parse a binding of a regexp to an identifier, i.e. expr as id
-fn get_binding<T: Tokenizer>(parser: &mut T, end: &token::Token, env: &Env)
-        -> Result<Regex, FatalError> {
+fn get_binding<'a, T: Tokenizer<'a>>(parser: &mut T, end: &token::Token, env: &Env)
+        -> Result<Regex, DiagnosticBuilder<'a>> {
     let expr = try!(get_concat(parser, end, env));
-    if try!(parser.eat_keyword(token::keywords::As)) {
+    if parser.eat_keyword(token::keywords::As) {
         let name = try!(parser.parse_ident());
         Ok(Box::new(regex::Bind(name, expr)))
     } else { Ok(expr) }
@@ -287,13 +288,13 @@ fn get_binding<T: Tokenizer>(parser: &mut T, end: &token::Token, env: &Env)
 // if we are not at the end of the current subexpression as indicated by
 // the end parameter, we try to read a | operator followed by another
 // expression which is parsed recursively (or is left-assoc)
-fn get_regex<T: Tokenizer>(parser: &mut T, end: &token::Token, env: &Env)
-    -> Result<Regex,FatalError> {
-    if try!(parser.eat(end)) {
+fn get_regex<'a, T: Tokenizer<'a>>(parser: &mut T, end: &token::Token, env: &Env)
+    -> Result<Regex,DiagnosticBuilder<'a>> {
+    if parser.eat(end) {
         return Err(parser.unexpected());
     }
     let left = try!(get_binding(parser, end, env));
-    if try!(parser.eat(end)) {
+    if parser.eat(end) {
         Ok(left)
     } else {
         try!(parser.expect(&token::BinOp(token::Or)));
@@ -305,8 +306,8 @@ fn get_regex<T: Tokenizer>(parser: &mut T, end: &token::Token, env: &Env)
 // a pattern is an association of a name to a regular expression
 // this function expects the next tokens to be id = reg, with id
 // being a non-keyword identifier and reg a literal constant
-fn get_pattern(parser: &mut Parser, env: &Env)
-        -> Result<(Ident, Regex),FatalError> {
+fn get_pattern<'a>(parser: &mut Parser<'a>, env: &Env)
+        -> Result<(Ident, Regex),DiagnosticBuilder<'a>> {
     let name = try!(parser.parse_ident());
     try!(parser.expect(&token::Eq));
     let reg = try!(get_regex(parser, &token::Semi, env));
@@ -319,11 +320,11 @@ fn get_pattern(parser: &mut Parser, env: &Env)
 // does not match. returns an error if it encounters a malformed
 // definition, otherwise return the "environment" containing named
 // regular expression definitions
-fn get_definitions(parser: &mut Parser)
-        -> Result<(Env, Vec<Regex>), FatalError> {
+fn get_definitions<'a>(parser: &mut Parser<'a>)
+        -> Result<(Env, Vec<Regex>), DiagnosticBuilder<'a>> {
     let mut env = HashMap::new();
     let mut defs = Vec::new();
-    while try!(parser.eat_keyword(keywords::Let)) {
+    while parser.eat_keyword(keywords::Let) {
         let (id, pat) = try!(get_pattern(parser, &env));
         env.insert(id.name, defs.len());
         defs.push(pat);
@@ -335,14 +336,14 @@ fn get_definitions(parser: &mut Parser)
 // list of rules of the form regex => action
 // stops as soon as we encounter a closing brace } which
 // indicates the end of the condition body
-fn get_condition(parser: &mut Parser, env: &Env)
-        -> Result<Vec<Rule>,FatalError> {
+fn get_condition<'a>(parser: &mut Parser<'a>, env: &Env)
+        -> Result<Vec<Rule>,DiagnosticBuilder<'a>> {
     let mut ret = Vec::new();
-    while !try!(parser.eat(&token::CloseDelim(token::Brace))) {
+    while !parser.eat(&token::CloseDelim(token::Brace)) {
         let pattern = try!(get_regex(parser, &token::FatArrow, env));
-        let action = parser.parse_expr();
+        let action = try!(parser.parse_expr());
         // optionnal comma for disambiguation
-        try!(parser.eat(&token::Comma));
+        parser.eat(&token::Comma);
         ret.push(Rule { pattern:pattern, action:action });
     }
     Ok(ret)
@@ -352,8 +353,8 @@ fn get_condition(parser: &mut Parser, env: &Env)
 // entries here may be either rules of the gorm regex => action
 // or "conditions" of the form condition { ... } that contains rules
 // rules outside conditions implicitely belong to the "INITIAL" condition
-fn get_conditions(parser: &mut Parser, env: &Env)
-        -> Result<Vec<Condition>,FatalError> {
+fn get_conditions<'a>(parser: &mut Parser<'a>, env: &Env)
+        -> Result<Vec<Condition>,DiagnosticBuilder<'a>> {
     // remember the names of the conditions we already
     // encountered and where we stored their rules in
     // the conditions array
@@ -384,8 +385,8 @@ fn get_conditions(parser: &mut Parser, env: &Env)
                     // ok it's a condition
                     // bump 2 times: the identifier and the lbrace
                     let sp = parser.span;
-                    try!(parser.bump());
-                    try!(parser.bump());
+                    parser.bump();
+                    parser.bump();
 
                     // parse the condition body
                     let rules = try!(get_condition(parser, env));
@@ -407,7 +408,7 @@ fn get_conditions(parser: &mut Parser, env: &Env)
                     // ok, it's not a condition, so it's a rule of the form
                     // regex => action, with regex beginning by an identifier
                     let reg = try!(get_regex(parser, &token::FatArrow, env));
-                    let expr = parser.parse_expr();
+                    let expr = try!(parser.parse_expr());
                     ret[0].rules.push(Rule { pattern: reg, action: expr });
                 }
             }
@@ -416,7 +417,7 @@ fn get_conditions(parser: &mut Parser, env: &Env)
                 // it's not an ident, but it may still be the
                 // beginning of a regular expression
                 let reg = try!(get_regex(parser, &token::FatArrow, env));
-                let expr = parser.parse_expr();
+                let expr = try!(parser.parse_expr());
                 ret[0].rules.push(Rule { pattern: reg, action: expr });
             }
         }
@@ -428,8 +429,8 @@ fn get_conditions(parser: &mut Parser, env: &Env)
 // runs the parsing of the full analyser description
 // - first gets an environment of the regular expression definitions
 // - then parses the definitions of the rules and the conditions
-pub fn parse(ident:Ident, parser: &mut Parser) ->
-        Result<LexerDef,FatalError> {
+pub fn parse<'a>(ident:Ident, parser: &mut Parser<'a>) ->
+        Result<LexerDef,DiagnosticBuilder<'a>> {
     let tokens = try!(get_tokens(parser));
     let props = try!(get_properties(parser));
     let (env, defs) = try!(get_definitions(parser));

--- a/codegen/src/regex.rs
+++ b/codegen/src/regex.rs
@@ -27,7 +27,7 @@ impl<T> CharSet<T> {
 }
 
 #[derive(Clone)]
-enum Const {
+pub enum Const {
     Class(CharSet<char>),
     NotClass(CharSet<char>),
     Char(char),
@@ -37,7 +37,7 @@ enum Const {
 pub type Regex = Box<RegexNode>;
 
 #[derive(Clone)]
-enum RegexNode {
+pub enum RegexNode {
     // binary operators
     Or(Regex, Regex),
     Cat(Regex, Regex),

--- a/codegen/src/rt.rs
+++ b/codegen/src/rt.rs
@@ -97,7 +97,7 @@ impl<R: ::std::io::Read> RustLexLexer<R> {
                 // done cheaply because most analysers won't need more
                 // than a couple of buffers
                 let unused_buffers_count = self.tok.buf;
-                for i in (0 .. unused_buffers_count) {
+                for i in 0 .. unused_buffers_count {
                     self.inp[i].valid = false;
                     self.inp[i].d.truncate(0);
                     self.inp.swap(i + unused_buffers_count, i);

--- a/codegen/tests/src/test.in.rs
+++ b/codegen/tests/src/test.in.rs
@@ -10,9 +10,11 @@ pub enum Token {
 
 rustlex! SimpleLexer {
     let A = 'a';
+    . => |_:&mut SimpleLexer<R>|     None
     A => |lexer:&mut SimpleLexer<R>| Some(TokA ( lexer.yystr() ))
 }
 
+#[test]
 fn test_simple() {
     let expected = vec!(TokA("a".to_string()), TokA("a".to_string()));
     let str = "aa";
@@ -33,9 +35,11 @@ pub enum TokenB {
 rustlex! OtherLexer {
     token TokenB;
     let B = 'b';
+    . => |_:&mut OtherLexer<R>|     None
     B => |lexer:&mut OtherLexer<R>| Some(TokB ( lexer.yystr() ))
 }
 
+#[test]
 fn test_other() {
     let expected = vec!(TokB("b".to_string()), TokB("b".to_string()));
     let str = "bb";

--- a/fsa/src/dfa.rs
+++ b/fsa/src/dfa.rs
@@ -4,7 +4,6 @@ use nfa::StateData;
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::hash::Hash;
-use std::iter::repeat;
 use std::io::Write;
 use bit_set::BitSet;
 
@@ -144,7 +143,7 @@ impl<T> Automaton<T> where T: nfa::StateData {
             let mut new_groups = Vec::with_capacity(self.states.len());
             let mut modified = false;
 
-            'g: for s in (0 .. groups.len()) {
+            'g: for s in 0 .. groups.len() {
                 let group = groups[s];
 
                 // check if we have a subgroup of the group of s
@@ -155,7 +154,7 @@ impl<T> Automaton<T> where T: nfa::StateData {
                     // 2 states are said similar if for each input
                     // symbol they have a transition to states that
                     // are in the same group of the current partition
-                    for i in (0 .. 255usize) {
+                    for i in 0 .. 255usize {
                         let (s1, s2) = (
                             self.states[st].trans[i],
                             self.states[s].trans[i]
@@ -277,7 +276,7 @@ impl<T> Automaton<T> where T: nfa::StateData {
 
         let mut i = 0usize;
         for st in self.states.iter() {
-            for ch in (0 .. 256usize) {
+            for ch in 0 .. 256usize {
                 match st.trans[ch] {
                     0 => (),
                     dst => {

--- a/fsa/src/nfa.rs
+++ b/fsa/src/nfa.rs
@@ -83,7 +83,7 @@ impl<T: State> Automaton<T> {
 
         macro_rules! add {
             ($state: expr) => {
-                if !ret.contains(&$state) {
+                if !ret.contains($state) {
                     ret.insert($state);
                     stack.push($state);
 
@@ -131,7 +131,7 @@ impl<T: State> Automaton<T> {
         write!(out, "\t");
 
         // outputs f1nal states as doublecircle-shaped nodes
-        for st in (0 .. self.states.len()) {
+        for st in 0 .. self.states.len() {
             if self.states[st].data() != T::Data::no_data() {
                 write!(out, "{} ", st);
             }
@@ -140,7 +140,7 @@ impl<T: State> Automaton<T> {
         writeln!(out, ";\n");
         writeln!(out, "\tnode [shape=circle];");
 
-        for st in (0 .. self.states.len()) {
+        for st in 0 .. self.states.len() {
             for ch in 0 .. 256 {
                 for dst in self.states[st].transition(ch as u8) {
                     let mut esc = String::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
 #![feature(plugin_registrar, rustc_private)]
 
 extern crate rustlex_codegen;
-extern crate rustc;
+extern crate rustc_plugin;
 
 pub use rustlex_codegen::rt;
 
 #[plugin_registrar]
-pub fn plugin_registrar(reg: &mut rustc::plugin::Registry) {
+pub fn plugin_registrar(reg: &mut rustc_plugin::Registry) {
     rustlex_codegen::plugin_registrar(reg);
 }


### PR DESCRIPTION
This is unfortunately duplicating a lot from #38 by @webmobster, which I saw only after doing the work.

However, I solved some things a little differently, so I want to offer the PR anyway. Notably, I didn't have to introduce special handling for the lifetime in `DiagnosticBuilder`, by introducing a lifetime to the Tokenizer trait. (Maybe this is also due to a change in nightly between the PRs?)

To check everything builds, I used the codegen/tests crate, with `cargo test` and `cargo test --features=syntex`. Checked with syntex 0.26.